### PR TITLE
Now with support for metadata elements on files.

### DIFF
--- a/libraries/SimpleVocab/Controller/Plugin/SelectFilter.php
+++ b/libraries/SimpleVocab/Controller/Plugin/SelectFilter.php
@@ -75,7 +75,6 @@ class SimpleVocab_Controller_Plugin_SelectFilter extends Zend_Controller_Plugin_
                            array($this, 'filterElementInput'));
                 add_filter(array('ElementInput', 'File', $elementSet->name, $element->name),
                            array($this, 'filterElementInput'));
-
             }
             // Once the filter is applied for one route there is no need to 
             // continue looping the routes.

--- a/libraries/SimpleVocab/Controller/Plugin/SelectFilter.php
+++ b/libraries/SimpleVocab/Controller/Plugin/SelectFilter.php
@@ -23,7 +23,7 @@ class SimpleVocab_Controller_Plugin_SelectFilter extends Zend_Controller_Plugin_
         array('module' => 'default', 'controller' => 'items', 
               'actions' => array('add', 'edit', 'change-type')), 
         array('module' => 'default', 'controller' => 'files',
-              'actions' => array('add', 'edit', 'change-type')),
+              'actions' => array('add', 'edit')),
         array('module' => 'default', 'controller' => 'elements',
               'actions' => array('element-form')),
     );

--- a/libraries/SimpleVocab/Controller/Plugin/SelectFilter.php
+++ b/libraries/SimpleVocab/Controller/Plugin/SelectFilter.php
@@ -22,8 +22,10 @@ class SimpleVocab_Controller_Plugin_SelectFilter extends Zend_Controller_Plugin_
     protected $_defaultRoutes = array(
         array('module' => 'default', 'controller' => 'items', 
               'actions' => array('add', 'edit', 'change-type')), 
-        array('module' => 'default', 'controller' => 'elements', 
-              'actions' => array('element-form')), 
+        array('module' => 'default', 'controller' => 'files',
+              'actions' => array('add', 'edit', 'change-type')),
+        array('module' => 'default', 'controller' => 'elements',
+              'actions' => array('element-form')),
     );
     
     /**
@@ -44,7 +46,7 @@ class SimpleVocab_Controller_Plugin_SelectFilter extends Zend_Controller_Plugin_
         $currentModule = is_null($request->getModuleName()) ? 'default' : $request->getModuleName();
         $currentController = $request->getControllerName();
         $currentAction = $request->getActionName();
-        
+
         // Allow plugins to register routes that contain form inputs rendered by 
         // Omeka_View_Helper_ElementForm::_displayFormInput().
         $routes = apply_filters('simple_vocab_routes', $this->_defaultRoutes);
@@ -70,7 +72,10 @@ class SimpleVocab_Controller_Plugin_SelectFilter extends Zend_Controller_Plugin_
                 $element = $db->getTable('Element')->find($element_id);
                 $elementSet = $db->getTable('ElementSet')->find($element->element_set_id);
                 add_filter(array('ElementInput', 'Item', $elementSet->name, $element->name), 
-                           array($this, 'filterElementInput'));
+                          array($this, 'filterElementInput'));
+                add_filter(array('ElementInput', 'File', $elementSet->name, $element->name),
+                          array($this, 'filterElementInput'));
+
             }
             // Once the filter is applied for one route there is no need to 
             // continue looping the routes.

--- a/libraries/SimpleVocab/Controller/Plugin/SelectFilter.php
+++ b/libraries/SimpleVocab/Controller/Plugin/SelectFilter.php
@@ -46,7 +46,7 @@ class SimpleVocab_Controller_Plugin_SelectFilter extends Zend_Controller_Plugin_
         $currentModule = is_null($request->getModuleName()) ? 'default' : $request->getModuleName();
         $currentController = $request->getControllerName();
         $currentAction = $request->getActionName();
-
+        
         // Allow plugins to register routes that contain form inputs rendered by 
         // Omeka_View_Helper_ElementForm::_displayFormInput().
         $routes = apply_filters('simple_vocab_routes', $this->_defaultRoutes);
@@ -72,9 +72,9 @@ class SimpleVocab_Controller_Plugin_SelectFilter extends Zend_Controller_Plugin_
                 $element = $db->getTable('Element')->find($element_id);
                 $elementSet = $db->getTable('ElementSet')->find($element->element_set_id);
                 add_filter(array('ElementInput', 'Item', $elementSet->name, $element->name), 
-                          array($this, 'filterElementInput'));
+                           array($this, 'filterElementInput'));
                 add_filter(array('ElementInput', 'File', $elementSet->name, $element->name),
-                          array($this, 'filterElementInput'));
+                           array($this, 'filterElementInput'));
 
             }
             // Once the filter is applied for one route there is no need to 


### PR DESCRIPTION
Hello, 

Would you be willing to support metadata elements on files as well as items?

I'm not sure if this is the best way to achieve this. Alternatively, you could provide another call to apply_filters to allow other plugins to add filters of their own. 

Would you prefer not to have the file controller as part of your default routes?

Thanks, 
-Adam
