### PR TITLE
Add links to terms

### DIFF
--- a/controllers/IndexController.php
+++ b/controllers/IndexController.php
@@ -130,10 +130,9 @@ class SimpleVocab_IndexController extends Omeka_Controller_AbstractActionControl
             
             $elementTexts[] = array('warnings' => $warnings, 
                                     'count' => $elementText->count, 
-                                    'text' => $elementText->text,
-                                    'element_id' => $elementId);
+                                    'text' => $elementText->text);
         }
-        
+        $this->view->element_id = $elementId;
         $this->view->element_texts = $elementTexts;
     }
     

--- a/controllers/IndexController.php
+++ b/controllers/IndexController.php
@@ -130,7 +130,8 @@ class SimpleVocab_IndexController extends Omeka_Controller_AbstractActionControl
             
             $elementTexts[] = array('warnings' => $warnings, 
                                     'count' => $elementText->count, 
-                                    'text' => $elementText->text);
+                                    'text' => $elementText->text,
+                                    'element_id' => $elementId);
         }
         
         $this->view->element_texts = $elementTexts;

--- a/views/admin/index/element-texts.ajax.php
+++ b/views/admin/index/element-texts.ajax.php
@@ -12,8 +12,17 @@
         <td><?php echo $element_text['count']; ?></td>
         <td class="error"><?php echo implode("<br />", $element_text['warnings']); ?></td>
         <td>
-            <a target="blank" href="<?php echo html_escape(url('items/browse?search=&advanced[0][joiner]=and&advanced[0][element_id]='.$element_text['element_id'].'&advanced[0][type]=is+exactly&advanced[0][terms]='.urlencode($element_text['text']))); ?>"><?php echo snippet(nl2br($element_text['text']), 0, 600); ?></a>
         <?php if (!get_option('simple_vocab_files')): ?>
+            <?php $url = url('items/browse', array(
+                'advanced' => array(
+                    array(
+                        'element_id' => $element_id,
+                        'type' => 'is exactly',
+                        'terms' => $element_text['text'],
+                    ),
+                ),
+            )); ?>
+            <a target="blank" href="<?php echo $url; ?>"><?php echo snippet(nl2br($element_text['text']), 0, 600); ?></a>
         <?php else: ?>
             <?php echo snippet(nl2br($element_text['text']), 0, 600); ?>
         <?php endif; ?>

--- a/views/admin/index/element-texts.ajax.php
+++ b/views/admin/index/element-texts.ajax.php
@@ -13,7 +13,7 @@
         <td class="error"><?php echo implode("<br />", $element_text['warnings']); ?></td>
         <td>
         <?php if(!get_option('simple_vocab_files')):?>
-            <a target="blank" href="<?php echo html_escape(url('items/browse?search=&advanced[0][joiner]=and&advanced[0][element_id]='.$element_text['element_id'].'&advanced[0][type]=is+exactly&advanced[0][terms]='.urlencode(str_replace('\n','%0D%0A',$element_text['text'])))); ?>"><?php echo snippet(nl2br($element_text['text']), 0, 600); ?></a>
+            <a target="blank" href="<?php echo html_escape(url('items/browse?search=&advanced[0][joiner]=and&advanced[0][element_id]='.$element_text['element_id'].'&advanced[0][type]=is+exactly&advanced[0][terms]='.urlencode($element_text['text']))); ?>"><?php echo snippet(nl2br($element_text['text']), 0, 600); ?></a>
         <?php else:?>
             <?php echo snippet(nl2br($element_text['text']), 0, 600); ?>
         <?php endif;?>

--- a/views/admin/index/element-texts.ajax.php
+++ b/views/admin/index/element-texts.ajax.php
@@ -12,13 +12,12 @@
         <td><?php echo $element_text['count']; ?></td>
         <td class="error"><?php echo implode("<br />", $element_text['warnings']); ?></td>
         <td>
-        <?php if(!get_option('simple_vocab_files')):?>
             <a target="blank" href="<?php echo html_escape(url('items/browse?search=&advanced[0][joiner]=and&advanced[0][element_id]='.$element_text['element_id'].'&advanced[0][type]=is+exactly&advanced[0][terms]='.urlencode($element_text['text']))); ?>"><?php echo snippet(nl2br($element_text['text']), 0, 600); ?></a>
-        <?php else:?>
+        <?php if (!get_option('simple_vocab_files')): ?>
+        <?php else: ?>
             <?php echo snippet(nl2br($element_text['text']), 0, 600); ?>
-        <?php endif;?>
+        <?php endif; ?>
         </td>
-        
     </tr>
     <?php endforeach; ?>
 </table>

--- a/views/admin/index/element-texts.ajax.php
+++ b/views/admin/index/element-texts.ajax.php
@@ -11,7 +11,14 @@
     <tr>
         <td><?php echo $element_text['count']; ?></td>
         <td class="error"><?php echo implode("<br />", $element_text['warnings']); ?></td>
-        <td><?php echo snippet(nl2br($element_text['text']), 0, 600); ?></td>
+        <td>
+        <?php if(!get_option('simple_vocab_files')):?>
+            <a target="blank" href="<?php echo html_escape(url('items/browse?search=&advanced[0][joiner]=and&advanced[0][element_id]='.$element_text['element_id'].'&advanced[0][type]=is+exactly&advanced[0][terms]='.$element_text['text'])); ?>"><?php echo snippet(nl2br($element_text['text']), 0, 600); ?></a>
+        <?php else:?>
+            <?php echo snippet(nl2br($element_text['text']), 0, 600); ?>
+        <?php endif;?>
+        </td>
+        
     </tr>
     <?php endforeach; ?>
 </table>

--- a/views/admin/index/element-texts.ajax.php
+++ b/views/admin/index/element-texts.ajax.php
@@ -13,7 +13,7 @@
         <td class="error"><?php echo implode("<br />", $element_text['warnings']); ?></td>
         <td>
         <?php if(!get_option('simple_vocab_files')):?>
-            <a target="blank" href="<?php echo html_escape(url('items/browse?search=&advanced[0][joiner]=and&advanced[0][element_id]='.$element_text['element_id'].'&advanced[0][type]=is+exactly&advanced[0][terms]='.$element_text['text'])); ?>"><?php echo snippet(nl2br($element_text['text']), 0, 600); ?></a>
+            <a target="blank" href="<?php echo html_escape(url('items/browse?search=&advanced[0][joiner]=and&advanced[0][element_id]='.$element_text['element_id'].'&advanced[0][type]=is+exactly&advanced[0][terms]='.urlencode(str_replace('\n','%0D%0A',$element_text['text'])))); ?>"><?php echo snippet(nl2br($element_text['text']), 0, 600); ?></a>
         <?php else:?>
             <?php echo snippet(nl2br($element_text['text']), 0, 600); ?>
         <?php endif;?>


### PR DESCRIPTION
This change adds links to the existing terms (unless the `simple_vocab_files` option is true). This allows admins to better deal with the information the plugin provides, e.g. by editing items where the selected term has warnings or other issues.